### PR TITLE
Remove commas from dictionary

### DIFF
--- a/dict/default/adjectives.txt
+++ b/dict/default/adjectives.txt
@@ -1355,7 +1355,6 @@ fetid
 feudal
 feverish
 few
-few,
 fewer
 fictional
 fictitious
@@ -2318,7 +2317,6 @@ manipulative
 manly
 manual
 many
-many,
 marbled
 marginal
 marked


### PR DESCRIPTION
There were a couple of words with a trailing comma, which resulted in generating an invalid subdomain.